### PR TITLE
Highlight sidebar nav based on scroll

### DIFF
--- a/app/company/[secCode]/marketcap/page.tsx
+++ b/app/company/[secCode]/marketcap/page.tsx
@@ -21,6 +21,7 @@ import CompanyLogo from "@/components/CompanyLogo";
 import { InteractiveChartSection } from "@/components/interactive-chart-section";
 import { KeyMetricsSection } from "@/components/key-metrics-section";
 import { KeyMetricsSidebar } from "@/components/key-metrics-sidebar";
+import { PageNavigation } from "@/components/page-navigation";
 
 /**
  * Generate static params for all company marketcap pages (SSG)
@@ -495,43 +496,35 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
           {/* 페이지 네비게이션 */}
           <div className="rounded-xl border bg-background p-4">
             <h3 className="text-sm font-semibold mb-3">페이지 내비게이션</h3>
-            <nav className="space-y-2">
-              <a
-                href="#company-overview"
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
-              >
-                <Building2 className="h-3 w-3" />
-                기업 개요
-              </a>
-              <a
-                href="#chart-analysis"
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
-              >
-                <BarChart3 className="h-3 w-3" />
-                차트 분석
-              </a>
-              <a
-                href="#securities-summary"
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
-              >
-                <ArrowLeftRight className="h-3 w-3" />
-                종목 비교
-              </a>
-              <a
-                href="#indicators"
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
-              >
-                <TrendingUp className="h-3 w-3" />
-                핵심 지표
-              </a>
-              <a
-                href="#annual-data"
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
-              >
-                <FileText className="h-3 w-3" />
-                연도별 데이터
-              </a>
-            </nav>
+            <PageNavigation
+              sections={[
+                {
+                  id: "company-overview",
+                  label: "기업 개요",
+                  icon: <Building2 className="h-3 w-3" />,
+                },
+                {
+                  id: "chart-analysis",
+                  label: "차트 분석",
+                  icon: <BarChart3 className="h-3 w-3" />,
+                },
+                {
+                  id: "securities-summary",
+                  label: "종목 비교",
+                  icon: <ArrowLeftRight className="h-3 w-3" />,
+                },
+                {
+                  id: "indicators",
+                  label: "핵심 지표",
+                  icon: <TrendingUp className="h-3 w-3" />,
+                },
+                {
+                  id: "annual-data",
+                  label: "연도별 데이터",
+                  icon: <FileText className="h-3 w-3" />,
+                },
+              ]}
+            />
           </div>
 
           {/* 핵심 지표 카드 */}

--- a/components/page-navigation.tsx
+++ b/components/page-navigation.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { ReactNode, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface PageNavigationSection {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+}
+
+interface PageNavigationProps {
+  sections: PageNavigationSection[];
+  /**
+   * Additional offset to account for fixed headers when determining the active section.
+   */
+  offset?: number;
+}
+
+export function PageNavigation({ sections, offset = 160 }: PageNavigationProps) {
+  const [activeSection, setActiveSection] = useState<string | null>(sections[0]?.id ?? null);
+  const activeRef = useRef<string | null>(sections[0]?.id ?? null);
+
+  useEffect(() => {
+    if (sections.length === 0) {
+      setActiveSection(null);
+      activeRef.current = null;
+      return;
+    }
+
+    const updateActiveSection = () => {
+      const scrollPosition = window.scrollY + offset;
+      let currentActive: string | null = sections[0]?.id ?? null;
+
+      for (const section of sections) {
+        const element = document.getElementById(section.id);
+        if (!element) continue;
+        const elementTop = element.getBoundingClientRect().top + window.scrollY;
+
+        if (scrollPosition >= elementTop - 4) {
+          currentActive = section.id;
+        }
+      }
+
+      if (currentActive !== activeRef.current) {
+        activeRef.current = currentActive;
+        setActiveSection(currentActive);
+      }
+    };
+
+    let ticking = false;
+    const handleScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        updateActiveSection();
+        ticking = false;
+      });
+    };
+
+    updateActiveSection();
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleScroll);
+    };
+  }, [sections, offset]);
+
+  useEffect(() => {
+    const firstSection = sections[0]?.id ?? null;
+    setActiveSection(firstSection);
+    activeRef.current = firstSection;
+  }, [sections]);
+
+  return (
+    <nav className="space-y-2">
+      {sections.map((section) => {
+        const isActive = activeSection === section.id;
+        return (
+          <a
+            key={section.id}
+            href={`#${section.id}`}
+            className={cn(
+              "flex items-center gap-2 text-sm transition-colors py-1",
+              isActive ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground"
+            )}
+            aria-current={isActive ? "page" : undefined}
+          >
+            {section.icon}
+            {section.label}
+          </a>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side PageNavigation component that observes scroll position and marks the active section
- replace the static sidebar anchors on the company market cap page with the new navigation component so the current section is highlighted

## Testing
- pnpm lint *(fails: existing `@typescript-eslint/no-explicit-any` errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68caa6607fd48331ae3829892bfb8c48