### PR TITLE
Highlight sidebar nav and keep market cap header visible

### DIFF
--- a/app/company/[secCode]/marketcap/page.tsx
+++ b/app/company/[secCode]/marketcap/page.tsx
@@ -1,7 +1,6 @@
 import { notFound } from "next/navigation";
 import { ChevronRightIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
-import { Balancer } from "react-wrap-balancer";
 import { Building2, BarChart3, ArrowLeftRight, TrendingUp, FileText } from "lucide-react";
 import { getSecurityByCode, getCompanySecurities } from "@/lib/data/security";
 import { getCompanyAggregatedMarketcap } from "@/lib/data/company";
@@ -17,10 +16,11 @@ import { CompanyMarketcapPager } from "@/components/pager-company-marketcap";
 import { formatNumber, formatDate, formatNumberWithSeparateUnit, formatChangeRate, formatDifference } from "@/lib/utils";
 import { CompanyFinancialTabs } from "@/components/company-financial-tabs";
 import { InteractiveSecuritiesSection } from "@/components/simple-interactive-securities";
-import CompanyLogo from "@/components/CompanyLogo";
 import { InteractiveChartSection } from "@/components/interactive-chart-section";
 import { KeyMetricsSection } from "@/components/key-metrics-section";
 import { KeyMetricsSidebar } from "@/components/key-metrics-sidebar";
+import { PageNavigation } from "@/components/page-navigation";
+import { StickyCompanyHeader } from "@/components/sticky-company-header";
 
 /**
  * Generate static params for all company marketcap pages (SSG)
@@ -205,23 +205,13 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
 
         {/* 페이지 제목 섹션 */}
         <div className="space-y-6">
-          <div className="space-y-2">
-            <div className="flex items-center gap-4 mb-4">
-              <CompanyLogo
-                companyName={displayName}
-                logoUrl={security.company?.logo}
-                size={64}
-                className="flex-shrink-0"
-              />
-              <div className="flex-1 min-w-0">
-                <h1 className="font-heading text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight">
-                  <Balancer>
-                    {displayName} 시가총액
-                  </Balancer>
-                </h1>
-              </div>
-            </div>
-            <p className="text-lg md:text-xl text-muted-foreground mt-2">
+          <div className="space-y-4">
+            <StickyCompanyHeader
+              displayName={displayName}
+              companyName={security.company?.korName || security.company?.name}
+              logoUrl={security.company?.logo}
+            />
+            <p className="text-base md:text-lg text-muted-foreground">
               기업 전체 가치와 종목별 시가총액 구성을 분석합니다
             </p>
           </div>
@@ -495,43 +485,35 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
           {/* 페이지 네비게이션 */}
           <div className="rounded-xl border bg-background p-4">
             <h3 className="text-sm font-semibold mb-3">페이지 내비게이션</h3>
-            <nav className="space-y-2">
-              <a
-                href="#company-overview"
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
-              >
-                <Building2 className="h-3 w-3" />
-                기업 개요
-              </a>
-              <a
-                href="#chart-analysis"
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
-              >
-                <BarChart3 className="h-3 w-3" />
-                차트 분석
-              </a>
-              <a
-                href="#securities-summary"
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
-              >
-                <ArrowLeftRight className="h-3 w-3" />
-                종목 비교
-              </a>
-              <a
-                href="#indicators"
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
-              >
-                <TrendingUp className="h-3 w-3" />
-                핵심 지표
-              </a>
-              <a
-                href="#annual-data"
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
-              >
-                <FileText className="h-3 w-3" />
-                연도별 데이터
-              </a>
-            </nav>
+            <PageNavigation
+              sections={[
+                {
+                  id: "company-overview",
+                  label: "기업 개요",
+                  icon: <Building2 className="h-3 w-3" />,
+                },
+                {
+                  id: "chart-analysis",
+                  label: "차트 분석",
+                  icon: <BarChart3 className="h-3 w-3" />,
+                },
+                {
+                  id: "securities-summary",
+                  label: "종목 비교",
+                  icon: <ArrowLeftRight className="h-3 w-3" />,
+                },
+                {
+                  id: "indicators",
+                  label: "핵심 지표",
+                  icon: <TrendingUp className="h-3 w-3" />,
+                },
+                {
+                  id: "annual-data",
+                  label: "연도별 데이터",
+                  icon: <FileText className="h-3 w-3" />,
+                },
+              ]}
+            />
           </div>
 
           {/* 핵심 지표 카드 */}

--- a/components/page-navigation.tsx
+++ b/components/page-navigation.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { ReactNode, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface PageNavigationSection {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+}
+
+interface PageNavigationProps {
+  sections: PageNavigationSection[];
+  /**
+   * Additional offset to account for fixed headers when determining the active section.
+   */
+  offset?: number;
+}
+
+export function PageNavigation({ sections, offset = 160 }: PageNavigationProps) {
+  const [activeSection, setActiveSection] = useState<string | null>(sections[0]?.id ?? null);
+  const activeRef = useRef<string | null>(sections[0]?.id ?? null);
+
+  useEffect(() => {
+    if (sections.length === 0) {
+      setActiveSection(null);
+      activeRef.current = null;
+      return;
+    }
+
+    const updateActiveSection = () => {
+      const scrollPosition = window.scrollY + offset;
+      let currentActive: string | null = sections[0]?.id ?? null;
+
+      for (const section of sections) {
+        const element = document.getElementById(section.id);
+        if (!element) continue;
+        const elementTop = element.getBoundingClientRect().top + window.scrollY;
+
+        if (scrollPosition >= elementTop - 4) {
+          currentActive = section.id;
+        }
+      }
+
+      if (currentActive !== activeRef.current) {
+        activeRef.current = currentActive;
+        setActiveSection(currentActive);
+      }
+    };
+
+    let ticking = false;
+    const handleScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        updateActiveSection();
+        ticking = false;
+      });
+    };
+
+    updateActiveSection();
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleScroll);
+    };
+  }, [sections, offset]);
+
+  useEffect(() => {
+    const firstSection = sections[0]?.id ?? null;
+    setActiveSection(firstSection);
+    activeRef.current = firstSection;
+  }, [sections]);
+
+  return (
+    <nav className="space-y-2">
+      {sections.map((section) => {
+        const isActive = activeSection === section.id;
+        return (
+          <a
+            key={section.id}
+            href={`#${section.id}`}
+            className={cn(
+              "flex items-center gap-2 text-sm transition-colors py-1",
+              isActive ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground"
+            )}
+            aria-current={isActive ? "page" : undefined}
+          >
+            {section.icon}
+            {section.label}
+          </a>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/sticky-company-header.tsx
+++ b/components/sticky-company-header.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Balancer } from "react-wrap-balancer";
+
+import CompanyLogo from "@/components/CompanyLogo";
+import { cn } from "@/lib/utils";
+
+interface StickyCompanyHeaderProps {
+  displayName: string;
+  companyName?: string | null;
+  logoUrl?: string | null;
+  /**
+   * Pixel offset from the top of the viewport that the header should respect
+   * when it becomes sticky. Keep this in sync with the `top-*` utility used in
+   * the component styles.
+   */
+  stickyOffset?: number;
+}
+
+const DEFAULT_STICKY_OFFSET = 80; // matches Tailwind's top-20 (5rem)
+
+export function StickyCompanyHeader({
+  displayName,
+  companyName,
+  logoUrl,
+  stickyOffset = DEFAULT_STICKY_OFFSET,
+}: StickyCompanyHeaderProps) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const headerOffsetRef = useRef<number>(0);
+  const [isPinned, setIsPinned] = useState(false);
+
+  useEffect(() => {
+    const measureOffset = () => {
+      const sentinel = sentinelRef.current;
+      if (!sentinel) {
+        headerOffsetRef.current = 0;
+        return;
+      }
+
+      headerOffsetRef.current = sentinel.getBoundingClientRect().top + window.scrollY;
+    };
+
+    const updatePinnedState = () => {
+      if (!headerOffsetRef.current && headerOffsetRef.current !== 0) {
+        return;
+      }
+
+      const shouldPin = window.scrollY + stickyOffset >= headerOffsetRef.current;
+      setIsPinned(prev => (prev === shouldPin ? prev : shouldPin));
+    };
+
+    const handleResize = () => {
+      measureOffset();
+      updatePinnedState();
+    };
+
+    measureOffset();
+    updatePinnedState();
+
+    window.addEventListener("scroll", updatePinnedState, { passive: true });
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("scroll", updatePinnedState);
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [stickyOffset]);
+
+  const logoSize = isPinned ? 40 : 56;
+
+  return (
+    <div className="relative">
+      <div ref={sentinelRef} aria-hidden className="h-0" />
+      <div
+        className={cn(
+          "sticky top-20 z-30 transition-all duration-200",
+          isPinned
+            ? "border-b border-border/60 bg-background/95 py-2 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/75"
+            : "py-6 sm:py-8"
+        )}
+      >
+        <div
+          className={cn(
+            "flex items-center transition-all duration-200",
+            isPinned ? "gap-3" : "gap-4"
+          )}
+        >
+          <CompanyLogo
+            companyName={companyName ?? displayName}
+            logoUrl={logoUrl}
+            size={logoSize}
+            className={cn(
+              "flex-shrink-0 transition-all duration-200",
+              isPinned ? "shadow-sm" : undefined
+            )}
+          />
+          <div className="min-w-0">
+            <h1
+              className={cn(
+                "font-heading font-bold tracking-tight transition-all duration-200",
+                isPinned ? "text-xl sm:text-2xl" : "text-3xl md:text-4xl lg:text-5xl"
+              )}
+            >
+              <Balancer>{displayName} 시가총액</Balancer>
+            </h1>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default StickyCompanyHeader;


### PR DESCRIPTION
## Summary
- add a client-side PageNavigation component that observes scroll position and marks the active section
- replace the static sidebar anchors on the company market cap page with the new navigation component so the current section is highlighted
- introduce a sticky market cap header that shrinks into a compact bar once it reaches the top of the viewport so the title stays visible while scrolling

## Testing
- pnpm lint *(fails: existing `@typescript-eslint/no-explicit-any` and other lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68caa6607fd48331ae3829892bfb8c48