### PR TITLE
Default marketcap listings to company routes

### DIFF
--- a/components/marketcap-compact-list.tsx
+++ b/components/marketcap-compact-list.tsx
@@ -45,7 +45,7 @@ interface Props {
  */
 export default function MarketcapCompactList({ items, limit, className }: Props) {
   const pathname = usePathname();
-  const linkType = pathname.includes('/marketcaps') ? 'company' : 'security';
+  const linkType = pathname.startsWith('/security') ? 'security' : 'company';
   const list = (limit ? items.slice(0, limit) : items).filter(Boolean);
 
   return (

--- a/components/server-table.tsx
+++ b/components/server-table.tsx
@@ -35,7 +35,7 @@ export function ServerTable({
     metric = 'marketcap'
 }: ServerTableProps) {
     const pathname = usePathname();
-    const linkType = pathname.includes('/marketcaps') ? 'company' : 'security';
+    const linkType = pathname.startsWith('/security') ? 'security' : 'company';
 
     return (
         <div className="border rounded-lg overflow-hidden bg-card mx-auto max-w-none">


### PR DESCRIPTION
## Summary
- default marketcap list links to company pages instead of security pages
- use security routes only when the current pathname is already under /security

## Testing
- pnpm lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cacc9dbc8c8331831dc46b31c77704