### PR TITLE
Restructure sticky company header markup

### DIFF
--- a/components/sticky-company-header.tsx
+++ b/components/sticky-company-header.tsx
@@ -122,7 +122,7 @@ export function StickyCompanyHeader({
   const logoSize = isPinned ? 40 : 56;
 
   return (
-    <div className="relative">
+    <>
       <div ref={sentinelRef} aria-hidden className="h-px w-full opacity-0" />
       <div
         className={cn(
@@ -160,7 +160,7 @@ export function StickyCompanyHeader({
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- return the sticky company header and its sentinel as siblings so the sticky container defines the component root
- keep the sentinel immediately before the sticky element so existing intersection logic continues working

## Testing
- `pnpm lint` *(fails: pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68caddb3ea388331a852072294c1a68b