### PR TITLE
Adjust company marketcap sidebar layout

### DIFF
--- a/app/company/[secCode]/marketcap/page.tsx
+++ b/app/company/[secCode]/marketcap/page.tsx
@@ -305,13 +305,16 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
 
               <CompanyFinancialTabs secCode={secCode} />
 
-              <KeyMetricsSection
-                companyMarketcapData={companyMarketcapData}
-                companySecs={companySecs}
-                security={security}
-                periodAnalysis={periodAnalysis}
-                marketCapRanking={marketCapRanking}
-              />
+              <div className="xl:hidden">
+                <KeyMetricsSection
+                  companyMarketcapData={companyMarketcapData}
+                  companySecs={companySecs}
+                  security={security}
+                  periodAnalysis={periodAnalysis}
+                  marketCapRanking={marketCapRanking}
+                  sectionId="indicators-mobile"
+                />
+              </div>
 
               {/* 연도별 데이터 섹션 */}
               <div id="annual-data" className="border-t border-red-100 dark:border-red-800/50 pt-8 pb-8 bg-red-50/20 dark:bg-red-900/20 rounded-xl -mx-4 px-4">
@@ -515,12 +518,14 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
 
             {/* 핵심 지표 카드 */}
             {companyMarketcapData && (
-              <KeyMetricsSidebar
-                companyMarketcapData={companyMarketcapData}
-                companySecs={companySecs}
-                security={security}
-                marketCapRanking={marketCapRanking}
-              />
+              <div id="indicators" className="scroll-mt-24">
+                <KeyMetricsSidebar
+                  companyMarketcapData={companyMarketcapData}
+                  companySecs={companySecs}
+                  security={security}
+                  marketCapRanking={marketCapRanking}
+                />
+              </div>
             )}
 
             {/* 종목별 시가총액 */}
@@ -540,7 +545,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
             )}
           </div>
         </div>
-      </div >
+      </div>
     </main>
   );
 }

--- a/components/key-metrics-section.tsx
+++ b/components/key-metrics-section.tsx
@@ -16,6 +16,7 @@ interface KeyMetricsSectionProps {
         rankChange: number;
         value: number | null;
     } | null;
+    sectionId?: string;
 }
 
 export function KeyMetricsSection({
@@ -24,6 +25,7 @@ export function KeyMetricsSection({
     security,
     periodAnalysis,
     marketCapRanking,
+    sectionId = "indicators",
 }: KeyMetricsSectionProps) {
     const pathname = usePathname();
     const searchParams = useSearchParams();
@@ -530,7 +532,10 @@ export function KeyMetricsSection({
     if (!periodAnalysis) return null;
 
     return (
-        <div id="indicators" className="py-8 -mx-4 px-4 bg-orange-50/20 dark:bg-orange-950/20 rounded-xl border-t border-orange-100 dark:border-orange-800/30">
+        <div
+            id={sectionId}
+            className="py-8 -mx-4 px-4 bg-orange-50/20 dark:bg-orange-950/20 rounded-xl border-t border-orange-100 dark:border-orange-800/30"
+        >
             <div className="flex items-center gap-3 mb-6">
                 <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-orange-100 dark:bg-orange-900/50">
                     <TrendingUp className="h-5 w-5 text-orange-600 dark:text-orange-400" />


### PR DESCRIPTION
## Summary
- hide the desktop key metrics carousel and move it into the sticky sidebar with a dedicated anchor
- allow the key metrics section component to accept a custom id so mobile and desktop sections don’t collide

## Testing
- pnpm lint *(fails: pre-existing lint errors around unexpected any usage in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cae30ea71c83319d9678cac02fa38d