### PR TITLE
Fix marquee animation by adding gap fallback

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -58,7 +58,7 @@
     transform: translateX(0);
     }
   to {
-    transform: translateX(calc(-100% - var(--gap)));
+    transform: translateX(calc(-100% - var(--gap, 0px)));
     }
   }
   @keyframes marquee-vertical {
@@ -66,7 +66,7 @@
     transform: translateY(0);
     }
   to {
-    transform: translateY(calc(-100% - var(--gap)));
+    transform: translateY(calc(-100% - var(--gap, 0px)));
     }
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -64,7 +64,7 @@ export default {
         },
         marquee: {
           "0%": { transform: "translateX(0%)" },
-          "100%": { transform: "translateX(-50%)" },
+          "100%": { transform: "translateX(calc(-50% - var(--gap, 0px)))" },
         },
       },
       animation: {


### PR DESCRIPTION
## Summary
- ensure marquee keyframes in global styles default the gap CSS variable to 0 so transforms remain valid when no gap is set
- align Tailwind marquee keyframes with the same gap fallback to keep animations running smoothly

## Testing
- `pnpm lint` *(fails: pre-existing lint errors for many files using explicit any / unused values)*

------
https://chatgpt.com/codex/tasks/task_e_68cb80be66cc8331988726c660fe24dc