### PR TITLE
Fix TradingView attribution helper duplication

### DIFF
--- a/app/company/[secCode]/marketcap/page.tsx
+++ b/app/company/[secCode]/marketcap/page.tsx
@@ -103,6 +103,36 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
   // Get market cap ranking for the security
   const marketCapRanking = await getSecurityMarketCapRanking(security.securityId);
 
+  const coerceVolumeValue = (primary: unknown, secondary?: unknown) => {
+    const candidates = [primary, secondary];
+
+    for (const candidate of candidates) {
+      if (candidate === null || candidate === undefined) {
+        continue;
+      }
+
+      if (typeof candidate === "number" && Number.isFinite(candidate)) {
+        return candidate;
+      }
+
+      if (typeof candidate === "bigint") {
+        const numeric = Number(candidate);
+        if (Number.isFinite(numeric)) {
+          return numeric;
+        }
+      }
+
+      if (typeof candidate === "string") {
+        const numeric = Number.parseFloat(candidate.replace(/,/g, ""));
+        if (Number.isFinite(numeric)) {
+          return numeric;
+        }
+      }
+    }
+
+    return null;
+  };
+
   const rawPrices = Array.isArray(security.prices) ? security.prices : [];
   const parsedPricePoints = rawPrices
     .map((price: any) => {
@@ -126,6 +156,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
 
       const resolvedHigh = highValue ?? Math.max(resolvedOpen, resolvedClose);
       const resolvedLow = lowValue ?? Math.min(resolvedOpen, resolvedClose);
+      const volumeValue = coerceVolumeValue(price?.volume, price?.fvolume);
 
       return {
         date,
@@ -134,6 +165,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
         high: Number(resolvedHigh),
         low: Number(resolvedLow),
         close: Number(resolvedClose),
+        volume: Number.isFinite(volumeValue) ? Number(volumeValue) : null,
       };
     })
     .filter((point): point is {
@@ -143,25 +175,32 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
       high: number;
       low: number;
       close: number;
-    } => !!point && Number.isFinite(point.open) && Number.isFinite(point.high) && Number.isFinite(point.low) && Number.isFinite(point.close));
+      volume: number | null;
+    } =>
+      !!point &&
+      Number.isFinite(point.open) &&
+      Number.isFinite(point.high) &&
+      Number.isFinite(point.low) &&
+      Number.isFinite(point.close));
 
   const sortedPricePoints = parsedPricePoints.sort((a, b) => a.date.getTime() - b.date.getTime());
 
-  const oneMonthAgo = new Date();
-  oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+  const extendedPeriodStart = new Date();
+  extendedPeriodStart.setMonth(extendedPeriodStart.getMonth() - 3);
 
-  let candlestickSeriesData = sortedPricePoints.filter((point) => point.date >= oneMonthAgo);
+  let candlestickSeriesData = sortedPricePoints.filter((point) => point.date >= extendedPeriodStart);
 
   if (!candlestickSeriesData.length) {
-    candlestickSeriesData = sortedPricePoints.slice(-30);
+    candlestickSeriesData = sortedPricePoints.slice(-90);
   }
 
-  const candlestickData = candlestickSeriesData.map(({ time, open, high, low, close }) => ({
+  const candlestickData = candlestickSeriesData.map(({ time, open, high, low, close, volume }) => ({
     time,
     open,
     high,
     low,
     close,
+    volume: Number.isFinite(volume ?? undefined) ? Number(volume) : undefined,
   }));
 
   // 🔥 기간별 시가총액 분석 계산 함수
@@ -323,41 +362,51 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
             </div>
           </header>
 
-          <div className="grid gap-8 lg:grid-cols-2 lg:items-stretch">
-            <div className="h-full space-y-4">
-              <div className="flex h-full flex-col rounded-2xl border border-border/60 bg-background/80 p-2 shadow-sm">
-                <InteractiveChartSection
-                  companyMarketcapData={companyMarketcapData}
-                  companySecs={companySecs}
-                  type="summary"
-                  selectedType={selectedType}
-                />
+          <div className="grid gap-8 lg:auto-rows-max lg:grid-cols-2 lg:items-stretch">
+            <div className="flex flex-col rounded-2xl border border-border/60 bg-background/80 shadow-sm">
+              <div className="px-5 pt-5">
+                <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+                  {displayName} 시가총액 일간 추이
+                </h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  최근 6개월 간의 주간 시가총액 흐름과 종목별 비중 변화를 살펴보세요.
+                </p>
               </div>
-
-              <div className="flex flex-col rounded-2xl border border-border/60 bg-background/80 shadow-sm">
-                <div className="flex items-start justify-between gap-2 px-5 pt-5">
-                  <div>
-                    <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">최근 한 달 캔들 차트</h3>
-                    <p className="text-xs text-muted-foreground">
-                      {displayName} ({currentTicker})의 일별 시가 · 고가 · 저가 · 종가 흐름
-                    </p>
-                  </div>
-                  <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                    1M
-                  </span>
-                </div>
-                <div className="px-3 pb-5 pt-3">
-                  <CandlestickChart data={candlestickData} />
+              <div className="flex flex-1 flex-col px-3 pb-5 pt-3">
+                <div className="min-h-[260px] flex-1">
+                  <InteractiveChartSection
+                    companyMarketcapData={companyMarketcapData}
+                    companySecs={companySecs}
+                    type="summary"
+                    selectedType={selectedType}
+                  />
                 </div>
               </div>
             </div>
 
-            <div className="space-y-4">
+            <div className="flex h-full">
               <CardCompanyMarketcap
                 data={companyMarketcapData}
                 market={market}
                 selectedType={selectedType}
               />
+            </div>
+
+            <div className="flex flex-col rounded-2xl border border-border/60 bg-background/80 shadow-sm lg:col-span-2">
+              <div className="flex items-start justify-between gap-2 px-5 pt-5">
+                <div>
+                  <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">최근 분기 가격 차트</h3>
+                  <p className="text-xs text-muted-foreground">
+                    {displayName} ({currentTicker})의 일별 시가 · 고가 · 저가 · 종가와 거래량 흐름
+                  </p>
+                </div>
+                <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-semibold tracking-[0.08em] text-muted-foreground">
+                  최근 3개월
+                </span>
+              </div>
+              <div className="px-3 pb-5 pt-3">
+                <CandlestickChart data={candlestickData} />
+              </div>
             </div>
           </div>
         </section>

--- a/components/card-company-marketcap.tsx
+++ b/components/card-company-marketcap.tsx
@@ -3,10 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
-import { Progress } from "@/components/ui/progress";
 import { formatNumber, formatDate } from "@/lib/utils";
-import Link from "next/link";
 import ChartPieMarketcap from "@/components/chart-pie-marketcap";
 import type { CompanyMarketcapAggregated } from "@/lib/data/company";
 
@@ -47,31 +44,26 @@ export default function CardCompanyMarketcap({ data, market = "KOSPI", selectedT
         }));
 
     return (
-        <Card className="w-full h-fit">
-            {/* 헤더 섹션 - 273px 높이에 맞게 조정 */}
-            <CardHeader className="pb-2">
-                <div className="space-y-2">
-                    <CardTitle className="text-base font-semibold text-foreground leading-tight">
-                        {displayName} 시가총액
+        <Card className="flex h-full w-full flex-col">
+            <CardHeader className="space-y-2 px-5 pt-5 pb-3">
+                <div className="space-y-1">
+                    <CardTitle className="text-base font-semibold leading-tight text-foreground">
+                        {displayName} 시가총액 구성
                     </CardTitle>
-                    <div className="flex items-center justify-between">
-                        <Badge variant="secondary" className="text-base px-3 py-1 font-bold">
+                    <div className="flex items-center justify-between text-sm text-muted-foreground">
+                        <Badge variant="secondary" className="px-3 py-1 text-sm font-semibold">
                             {formatNumber(data.totalMarketcap)}원
                         </Badge>
-                        <p className="text-sm text-muted-foreground">
-                            {formatDate(data.totalMarketcapDate)}
-                        </p>
+                        <p>{formatDate(data.totalMarketcapDate)}</p>
                     </div>
                 </div>
             </CardHeader>
 
-            <CardContent className="px-4 pb-4 pt-0">
-                {/* 반응형 파이 차트 섹션 */}
-                <div className="space-y-4">
-                    {/* 파이 차트 - 조건부 렌더링으로 변경 */}
+            <CardContent className="flex flex-1 flex-col px-5 pb-5 pt-0">
+                <div className="flex-1 space-y-3">
                     <div className="w-full">
                         {screenSize === 'mobile' && (
-                            <div className="h-[220px] min-h-[220px]">
+                            <div className="h-[200px] min-h-[200px]">
                                 <ChartPieMarketcap
                                     data={chartData}
                                     centerText={{
@@ -84,7 +76,7 @@ export default function CardCompanyMarketcap({ data, market = "KOSPI", selectedT
                         )}
 
                         {screenSize === 'tablet' && (
-                            <div className="h-[280px] min-h-[280px]">
+                            <div className="h-[240px] min-h-[240px]">
                                 <ChartPieMarketcap
                                     data={chartData}
                                     centerText={{
@@ -97,7 +89,7 @@ export default function CardCompanyMarketcap({ data, market = "KOSPI", selectedT
                         )}
 
                         {screenSize === 'desktop' && (
-                            <div className="h-[350px] min-h-[350px]">
+                            <div className="h-[280px] min-h-[280px]">
                                 <ChartPieMarketcap
                                     data={chartData}
                                     centerText={{
@@ -110,7 +102,7 @@ export default function CardCompanyMarketcap({ data, market = "KOSPI", selectedT
                         )}
 
                         {screenSize === 'desktop-sidebar' && (
-                            <div className="h-[282px] min-h-[282px]">
+                            <div className="h-[260px] min-h-[260px]">
                                 <ChartPieMarketcap
                                     data={chartData}
                                     centerText={{


### PR DESCRIPTION
## Summary
- hoist the TradingView attribution removal helper so it can be reused without duplicate declarations
- reuse the shared helper when initializing the candlestick chart and its mutation observer
- normalize candlestick volume inputs so the histogram renders when data arrives as bigint or string values

## Testing
- pnpm lint *(fails: longstanding @typescript-eslint/no-explicit-any violations across the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cdef091d708331bb2da135415d2fcd