### PR TITLE
Adjust security price history ordering

### DIFF
--- a/lib/data/security.ts
+++ b/lib/data/security.ts
@@ -285,7 +285,10 @@ export const getSecurityByCode = unstable_cache(
           where: eq(schema.security.ticker, parsed.code),
           with: {
             company: true,
-            prices: { orderBy: [schema.price.date], limit: 30 },
+            prices: {
+              orderBy: [desc(schema.price.date)],
+              limit: 180,
+            },
             marketcaps: { orderBy: [schema.marketcap.date], limit: 100 },
           },
         });
@@ -297,7 +300,12 @@ export const getSecurityByCode = unstable_cache(
             securities: {
               where: eq(schema.security.type, '보통주'),
               limit: 1,
-              with: { prices: { orderBy: [schema.price.date], limit: 30 } },
+              with: {
+                prices: {
+                  orderBy: [desc(schema.price.date)],
+                  limit: 180,
+                },
+              },
             },
           },
         });
@@ -310,7 +318,10 @@ export const getSecurityByCode = unstable_cache(
           where: eq(schema.security.name, decodedParam),
           with: {
             company: true,
-            prices: { orderBy: [schema.price.date], limit: 30 },
+            prices: {
+              orderBy: [desc(schema.price.date)],
+              limit: 180,
+            },
             marketcaps: { orderBy: [schema.marketcap.date], limit: 100 },
           },
         });
@@ -320,7 +331,10 @@ export const getSecurityByCode = unstable_cache(
           where: eq(schema.security.ticker, decodedParam),
           with: {
             company: true,
-            prices: { orderBy: [schema.price.date], limit: 30 },
+            prices: {
+              orderBy: [desc(schema.price.date)],
+              limit: 180,
+            },
             marketcaps: { orderBy: [schema.marketcap.date], limit: 100 },
           },
         });
@@ -332,7 +346,12 @@ export const getSecurityByCode = unstable_cache(
             securities: {
               where: eq(schema.security.type, '보통주'),
               limit: 1,
-              with: { prices: { orderBy: [schema.price.date], limit: 30 } },
+              with: {
+                prices: {
+                  orderBy: [desc(schema.price.date)],
+                  limit: 180,
+                },
+              },
             },
           },
         });
@@ -348,7 +367,12 @@ export const getSecurityByCode = unstable_cache(
               securities: {
                 where: eq(schema.security.type, '보통주'),
                 limit: 1,
-                with: { prices: { orderBy: [schema.price.date], limit: 30 } },
+                with: {
+                  prices: {
+                    orderBy: [desc(schema.price.date)],
+                    limit: 180,
+                  },
+                },
               },
             },
           });


### PR DESCRIPTION
## Summary
- update all getSecurityByCode lookup paths to request up to 180 recent price rows ordered descending so downstream consumers receive reverse-chronological data

## Testing
- pnpm lint *(fails: existing repository lint errors for @typescript-eslint/no-explicit-any and other warnings unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ce20076b608331bc20981ebb8d024e