### PR TITLE
Expand company marketcap period analysis to 30 years

### DIFF
--- a/app/company/[secCode]/marketcap/page-new.tsx
+++ b/app/company/[secCode]/marketcap/page-new.tsx
@@ -81,7 +81,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
             { label: '3년 평균', months: 36, desc: '최근 3년' },
             { label: '5년 평균', months: 60, desc: '최근 5년' },
             { label: '10년 평균', months: 120, desc: '최근 10년' },
-            { label: '20년 평균', months: 240, desc: '최근 20년' }
+            { label: '30년 평균', months: 360, desc: '최근 30년' }
         ];
 
         const analysis = periods.map(period => {

--- a/app/company/[secCode]/marketcap/page.tsx
+++ b/app/company/[secCode]/marketcap/page.tsx
@@ -239,7 +239,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
       { label: '3년 평균', months: 36, desc: '최근 3년' },
       { label: '5년 평균', months: 60, desc: '최근 5년' },
       { label: '10년 평균', months: 120, desc: '최근 10년' },
-      { label: '20년 평균', months: 240, desc: '최근 20년' }
+      { label: '30년 평균', months: 360, desc: '최근 30년' }
     ];
 
     const analysis = periods.map(period => {


### PR DESCRIPTION
## Summary
- update the company marketcap period analysis to use a 30-year average so the full dataset can surface
- keep the alternate marketcap page implementation in sync with the same 30-year window

## Testing
- pnpm lint *(fails: pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ce24467fd88331b94348a650879626