### PR TITLE
Use green accent for price-volume separators

### DIFF
--- a/components/chart-candlestick.tsx
+++ b/components/chart-candlestick.tsx
@@ -154,10 +154,14 @@ function normalizeVolumeValue(volume: CandlestickPoint["volume"]): number | null
   return null;
 }
 
+const VOLUME_ACCENT_RGB = "38, 166, 154";
+
 const koreanPriceFormatter = new Intl.NumberFormat("ko-KR", {
   maximumFractionDigits: 0,
   minimumFractionDigits: 0,
 });
+
+const volumeAccent = (alpha: number) => `rgba(${VOLUME_ACCENT_RGB}, ${alpha})`;
 
 const koreanVolumeFormatter = new Intl.NumberFormat("ko-KR", {
   notation: "compact",
@@ -360,8 +364,8 @@ export function CandlestickChart({ data }: CandlestickChartProps) {
         textColor: foreground,
         background: { type: ColorType.Solid, color: "transparent" },
         panes: {
-          separatorColor: "rgba(214, 0, 0, 0.35)",
-          separatorHoverColor: "rgba(214, 0, 0, 0.55)",
+          separatorColor: volumeAccent(0.35),
+          separatorHoverColor: volumeAccent(0.55),
           enableResize: false,
         },
       },
@@ -492,7 +496,7 @@ export function CandlestickChart({ data }: CandlestickChartProps) {
           lastValueVisible: true,
           crosshairMarkerVisible: true,
           lineWidth: 2,
-          color: "rgba(214, 0, 0, 0.85)",
+          color: volumeAccent(0.85),
           priceScaleId: "volume",
           pointMarkersVisible: false,
         });


### PR DESCRIPTION
## Summary
- add a shared helper to generate rgba variants of the lightweight charts green accent color
- apply the green accent to the pane separator between price and volume and to the volume line color

## Testing
- pnpm lint *(fails: pre-existing lint errors about `any` usage in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf160cfafc8331bee1ef4c3e16288f