### PR TITLE
Hide left volume axis on candlestick chart

### DIFF
--- a/components/chart-candlestick.tsx
+++ b/components/chart-candlestick.tsx
@@ -374,7 +374,7 @@ export function CandlestickChart({ data }: CandlestickChartProps) {
         vertLines: { color: "rgba(148, 163, 184, 0.16)" },
       },
       leftPriceScale: {
-        visible: true,
+        visible: false,
         borderColor,
       },
       rightPriceScale: { borderColor },
@@ -466,7 +466,7 @@ export function CandlestickChart({ data }: CandlestickChartProps) {
 
     chart.applyOptions({
       leftPriceScale: {
-        visible: hasVolumeData,
+        visible: false,
         borderColor,
       },
       rightPriceScale: { borderColor },
@@ -514,7 +514,7 @@ export function CandlestickChart({ data }: CandlestickChartProps) {
         borderColor,
         mode: PriceScaleMode.Normal,
         autoScale: true,
-        position: "left",
+        position: "right",
         scaleMargins: {
           top: 0.1,
           bottom: 0,


### PR DESCRIPTION
## Summary
- hide the redundant left price scale when rendering the candlestick chart
- position the volume pane price scale on the right to reclaim space for the chart area

## Testing
- `pnpm lint` *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d070e8749883319ff8519ba9eab73f