### PR TITLE
Restore securities gradient and solid card surface

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -157,6 +157,13 @@
   }
 }
 
+@layer components {
+  .securities-card-surface {
+    background-color: var(--muted);
+    background-color: color-mix(in oklch, var(--background) 70%, var(--muted) 30%);
+  }
+}
+
 /* Enhanced visual hierarchy for financial data */
 /* Add specific typography and color emphasis for key financial values */
 

--- a/components/card-marketcap.tsx
+++ b/components/card-marketcap.tsx
@@ -156,8 +156,8 @@ function cardMarketcap({
       return "bg-background text-foreground border border-border shadow-sm";
     }
 
-    // CM-1-3A-2: 기본 상태 스타일 (회색 배경 + 투명 테두리 + 투명 그림자로 공간 유지)
-    return "bg-muted/30 hover:bg-muted/50 transition-all duration-200 border border-transparent shadow-sm shadow-transparent";
+    // CM-1-3A-2: 기본 상태 스타일 (불투명 카드 배경으로 섹션 배경 투과 방지)
+    return "securities-card-surface text-card-foreground transition-all duration-200 border border-border/60 hover:border-border hover:shadow-sm";
   };
 
   /*


### PR DESCRIPTION
## Summary
- revert the securities section gradient to its original light transparency
- add a reusable opaque surface style for securities cards that preserves their neutral tone
- update the market cap card styling to use the solid surface so section gradients no longer show through

## Testing
- `pnpm lint` *(fails: numerous pre-existing @typescript-eslint/no-explicit-any violations in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0956f461083319fa71d1c72a7bb93