### PR TITLE
Solidify inactive securities cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -157,6 +157,32 @@
   }
 }
 
+@layer components {
+  .securities-card-surface {
+    /*
+      카드 기본면은 기존 bg-muted/30이 주던 옅은 회색감을 유지하되
+      완전히 불투명하게 만들어 섹션 그라디언트가 비치지 않도록 한다.
+      color-mix를 이용해 배경(흰색)과 전경(짙은 남색)을 섞어 중립적인 회색을 생성한다.
+    */
+    background-color: color-mix(in oklch, var(--background) 68%, var(--foreground) 32%);
+  }
+
+  .dark .securities-card-surface {
+    /* 다크 모드에서는 배경이 짙기 때문에 muted 톤과 배경을 섞어 부드러운 암회색을 만든다. */
+    background-color: color-mix(in oklch, var(--background) 78%, var(--muted) 22%);
+  }
+
+  @supports not (color: color-mix(in oklch, black 50%, white 50%)) {
+    .securities-card-surface {
+      background-color: oklch(0.92 0.01 255.5);
+    }
+
+    .dark .securities-card-surface {
+      background-color: oklch(0.31 0.02 255.5);
+    }
+  }
+}
+
 /* Enhanced visual hierarchy for financial data */
 /* Add specific typography and color emphasis for key financial values */
 

--- a/components/card-marketcap.tsx
+++ b/components/card-marketcap.tsx
@@ -156,8 +156,8 @@ function cardMarketcap({
       return "bg-background text-foreground border border-border shadow-sm";
     }
 
-    // CM-1-3A-2: 기본 상태 스타일 (회색 배경 + 투명 테두리 + 투명 그림자로 공간 유지)
-    return "bg-muted/30 hover:bg-muted/50 transition-all duration-200 border border-transparent shadow-sm shadow-transparent";
+    // CM-1-3A-2: 기본 상태 스타일 (불투명 카드 배경으로 섹션 배경 투과 방지)
+    return "securities-card-surface text-card-foreground transition-all duration-200 border border-border hover:border-border hover:shadow-sm";
   };
 
   /*


### PR DESCRIPTION
## Summary
- adjust the `securities-card-surface` utility to render an opaque neutral surface in both light and dark themes so section gradients no longer shine through
- use the solid border token on inactive market cap cards to reinforce the opaque surface treatment

## Testing
- `pnpm lint` *(fails: numerous pre-existing @typescript-eslint/no-explicit-any violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d0956f461083319fa71d1c72a7bb93