### PR TITLE
Reduce market cap chart heights and center breakdown legend

### DIFF
--- a/components/chart-marketcap.tsx
+++ b/components/chart-marketcap.tsx
@@ -191,7 +191,7 @@ function ChartMarketcap({ data, format, formatTooltip, selectedType = "시가총
 
   if (!isClient || !data || data.length === 0) {
     return (
-      <div className="w-full h-[250px] sm:h-[280px] md:h-[320px] lg:h-[350px] xl:h-[380px] flex items-center justify-center">
+      <div className="w-full h-[200px] sm:h-[220px] md:h-[240px] lg:h-[260px] xl:h-[280px] flex items-center justify-center">
         <div className="text-sm text-gray-500 dark:text-gray-400">
           {!isClient ? "차트 로딩 중..." : "차트 데이터가 없습니다"}
         </div>
@@ -200,8 +200,8 @@ function ChartMarketcap({ data, format, formatTooltip, selectedType = "시가총
   }
 
   return (
-    <div className="w-full h-[250px] sm:h-[280px] md:h-[320px] lg:h-[350px] xl:h-[380px]">
-      <ResponsiveContainer width="100%" height="100%" minWidth={300} minHeight={250}>
+    <div className="w-full h-[200px] sm:h-[220px] md:h-[240px] lg:h-[260px] xl:h-[280px]">
+      <ResponsiveContainer width="100%" height="100%" minWidth={300} minHeight={200}>
         <LineChart
           data={safeData}
           margin={{ top: 8, right: 12, left: 8, bottom: 10 }}

--- a/components/chart-pie-marketcap.tsx
+++ b/components/chart-pie-marketcap.tsx
@@ -301,7 +301,7 @@ export default function ChartPieMarketcap({ data, centerText, selectedType = '�
         return [totalRow];
     }, [stackedSegments]);
 
-    const stackedBarHeight = 68;
+    const stackedBarHeight = 56;
 
     if (!isClient || chartData.length === 0) {
         return (
@@ -314,9 +314,9 @@ export default function ChartPieMarketcap({ data, centerText, selectedType = '�
     }
 
     return (
-        <div className="flex h-full w-full flex-col gap-4">
-            <div className="relative min-h-[240px] flex-1">
-                <ResponsiveContainer width="100%" height="100%" minWidth={220} minHeight={240}>
+        <div className="flex h-full w-full flex-col gap-3.5">
+            <div className="relative min-h-[200px] flex-1">
+                <ResponsiveContainer width="100%" height="100%" minWidth={220} minHeight={200}>
                     <PieChart>
                         <Pie
                             data={chartData}
@@ -367,7 +367,7 @@ export default function ChartPieMarketcap({ data, centerText, selectedType = '�
                 )}
             </div>
 
-            <div className="flex flex-col gap-2.5">
+            <div className="flex flex-col gap-2">
                 <div className="relative flex items-center justify-center" style={{ minHeight: stackedBarHeight }}>
                     <ResponsiveContainer width="90%" height={stackedBarHeight} minWidth={200}>
                         <BarChart data={stackedBarData} layout="vertical" margin={{ top: 6, right: 12, bottom: 6, left: 12 }}>
@@ -394,7 +394,7 @@ export default function ChartPieMarketcap({ data, centerText, selectedType = '�
                 </div>
 
                 <div
-                    className="flex flex-nowrap items-center overflow-x-auto text-[11px] text-slate-500 dark:text-slate-400"
+                    className="flex w-full flex-nowrap items-center justify-center overflow-x-auto text-center text-[11px] text-slate-500 dark:text-slate-400"
                     role="list"
                     aria-label="시가총액 구성 종목"
                 >


### PR DESCRIPTION
## Summary
- shrink the daily market cap line chart container and responsive minimum height to remove excess vertical space
- reduce the market cap composition chart spacing, lower its pie container height, and tighten the stacked bar footprint
- center-align the market cap composition legend row while preserving scroll overflow behaviour

## Testing
- pnpm lint *(fails: existing lint errors unrelated to the charts)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d78958ac8331915dad62621f50f4