### PR TITLE
Adjust marketcap composition chart height

### DIFF
--- a/components/card-company-marketcap.tsx
+++ b/components/card-company-marketcap.tsx
@@ -44,10 +44,10 @@ export default function CardCompanyMarketcap({ data, market = "KOSPI", selectedT
         }));
 
     const chartContainerHeights: Record<typeof screenSize, string> = {
-        mobile: "h-[360px] min-h-[360px]",
-        tablet: "h-[380px] min-h-[380px]",
-        desktop: "h-[420px] min-h-[420px]",
-        "desktop-sidebar": "h-[400px] min-h-[400px]",
+        mobile: "h-[260px] min-h-[260px]",
+        tablet: "h-[260px] min-h-[260px]",
+        desktop: "h-[280px] min-h-[280px]",
+        "desktop-sidebar": "h-[280px] min-h-[280px]",
     };
 
     return (


### PR DESCRIPTION
## Summary
- lower the company market cap composition pie chart container heights so they better align with the adjacent daily trend chart

## Testing
- pnpm lint *(fails: pre-existing lint errors about `@typescript-eslint/no-explicit-any` and related warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d0da4fe4d88331ad9db1cc3c22c98e