### PR TITLE
Adjust pie chart prominence in market cap card

### DIFF
--- a/components/chart-pie-marketcap.tsx
+++ b/components/chart-pie-marketcap.tsx
@@ -314,7 +314,7 @@ export default function ChartPieMarketcap({ data, centerText, selectedType = 'ì‹
     }
 
     return (
-        <div className="flex h-full w-full flex-col gap-3.5">
+        <div className="flex h-full w-full flex-col gap-2.5">
             <div className="relative min-h-[200px] flex-1">
                 <ResponsiveContainer width="100%" height="100%" minWidth={220} minHeight={200}>
                     <PieChart>
@@ -324,8 +324,8 @@ export default function ChartPieMarketcap({ data, centerText, selectedType = 'ì‹
                             cy="50%"
                             labelLine={false}
                             label={CustomLabel}
-                            outerRadius="78%"
-                            innerRadius="26%"
+                            outerRadius="86%"
+                            innerRadius="28%"
                             fill="#8884d8"
                             dataKey="value"
                             stroke="#ffffff"


### PR DESCRIPTION
## Summary
- increase the market cap pie chart radius to make it visually larger while retaining the overall container height
- tighten vertical spacing in the pie chart card so the stacked bar and legend sit closer beneath the enlarged pie chart

## Testing
- `pnpm lint` *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0dd8063f083318f688c9394c69059