### PR TITLE
Adjust market cap pie chart proportions

### DIFF
--- a/components/chart-pie-marketcap.tsx
+++ b/components/chart-pie-marketcap.tsx
@@ -314,9 +314,9 @@ export default function ChartPieMarketcap({ data, centerText, selectedType = 'ì‹
     }
 
     return (
-        <div className="flex h-full w-full flex-col gap-2.5">
-            <div className="relative min-h-[200px] flex-1">
-                <ResponsiveContainer width="100%" height="100%" minWidth={220} minHeight={200}>
+        <div className="flex h-full w-full flex-col gap-3">
+            <div className="relative flex-1" style={{ minHeight: 240 }}>
+                <ResponsiveContainer width="100%" height="100%" minWidth={240} minHeight={240}>
                     <PieChart>
                         <Pie
                             data={chartData}
@@ -324,8 +324,8 @@ export default function ChartPieMarketcap({ data, centerText, selectedType = 'ì‹
                             cy="50%"
                             labelLine={false}
                             label={CustomLabel}
-                            outerRadius="92%"
-                            innerRadius="28%"
+                            outerRadius="100%"
+                            innerRadius="32%"
                             fill="#8884d8"
                             dataKey="value"
                             stroke="#ffffff"


### PR DESCRIPTION
## Summary
- enlarge the market cap pie chart container height and radii so the chart fills more of its card
- tweak layout spacing so the stacked bar automatically sits lower beneath the enlarged pie

## Testing
- pnpm lint *(fails: existing `@typescript-eslint/no-explicit-any` violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e698d90083318623ef4f6c092927