### PR TITLE
Adjust mobile header to show company identity when pinned

### DIFF
--- a/app/company/layout.tsx
+++ b/app/company/layout.tsx
@@ -2,6 +2,7 @@ import { getSecuritySearchNames } from "@/lib/getSearch";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 import { BottomNavigation } from "@/components/bottom-navigation";
+import { MobileHeaderProvider } from "@/components/mobile-header-context";
 
 interface CompanyLayoutProps {
   children: React.ReactNode;
@@ -11,7 +12,7 @@ export default async function CompanyLayout({ children }: CompanyLayoutProps) {
   const searchData = await getSecuritySearchNames();
 
   return (
-    <>
+    <MobileHeaderProvider>
       <SiteHeader searchData={searchData} />
       <main className="flex-1 pb-20 md:pb-0">
         <div className="container mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
@@ -20,6 +21,6 @@ export default async function CompanyLayout({ children }: CompanyLayoutProps) {
       </main>
       <SiteFooter />
       <BottomNavigation />
-    </>
+    </MobileHeaderProvider>
   );
 }

--- a/components/mobile-header-context.tsx
+++ b/components/mobile-header-context.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type MobileHeaderContent = {
+  type: "company";
+  displayName: string;
+  companyName?: string | null;
+  logoUrl?: string | null;
+};
+
+type MobileHeaderContextValue = {
+  content: MobileHeaderContent | null;
+  setContent: (content: MobileHeaderContent | null) => void;
+};
+
+const noop = () => {};
+
+const defaultValue: MobileHeaderContextValue = {
+  content: null,
+  setContent: noop,
+};
+
+const MobileHeaderContext = createContext<MobileHeaderContextValue | undefined>(
+  undefined
+);
+
+export function MobileHeaderProvider({ children }: { children: ReactNode }) {
+  const [content, setContentState] = useState<MobileHeaderContent | null>(null);
+
+  const setContent = useCallback((next: MobileHeaderContent | null) => {
+    setContentState(prev => {
+      if (prev === next) {
+        return prev;
+      }
+
+      if (!prev && !next) {
+        return prev;
+      }
+
+      if (!prev || !next) {
+        return next ?? null;
+      }
+
+      const isSame =
+        prev.type === next.type &&
+        prev.displayName === next.displayName &&
+        prev.companyName === next.companyName &&
+        prev.logoUrl === next.logoUrl;
+
+      return isSame ? prev : next;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      content,
+      setContent,
+    }),
+    [content, setContent]
+  );
+
+  return (
+    <MobileHeaderContext.Provider value={value}>
+      {children}
+    </MobileHeaderContext.Provider>
+  );
+}
+
+export function useMobileHeader() {
+  return useContext(MobileHeaderContext) ?? defaultValue;
+}
+

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,9 +1,15 @@
+"use client";
+
 import Link from "next/link";
 import Image from "next/image";
+
+import CompanyLogo from "@/components/CompanyLogo";
+import { CommandMenu } from "@/components/command-menu";
 import { MainNav } from "@/components/main-nav";
 import { MobileNav } from "@/components/mobile-nav";
 import { ModeToggle } from "@/components/mode-toggle";
-import { CommandMenu } from "@/components/command-menu";
+import { useMobileHeader } from "@/components/mobile-header-context";
+import { cn } from "@/lib/utils";
 
 // Define props for SiteHeader to accept searchData
 interface SiteHeaderProps {
@@ -16,8 +22,14 @@ interface SiteHeaderProps {
   }[];
 }
 
-const Logo = () => (
-  <Link href="/" className="flex items-center space-x-2">
+const Logo = ({ showMobileVariant = true }: { showMobileVariant?: boolean }) => (
+  <Link
+    href="/"
+    className={cn(
+      "items-center space-x-2",
+      showMobileVariant ? "flex" : "hidden sm:flex"
+    )}
+  >
     {/* Default (sm and up) */}
     <div className="hidden sm:flex items-center space-x-1.5 px-3 py-2 rounded-lg transition-all duration-300 group">
       <span
@@ -44,33 +56,64 @@ const Logo = () => (
     </div>
 
     {/* XS layout */}
-    <div className="flex sm:hidden items-center space-x-1.5 px-2 py-2 rounded-lg transition-all duration-300 group">
-      <span
-        className="font-serif font-bold text-lg text-rose-500 transition-all duration-300"
-        style={{ textShadow: "-1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000" }}
-      >
-        천하
-      </span>
-      <div className="relative">
-        <Image
-          src="/icon.svg"
-          alt="로고"
-          width={24}
-          height={24}
-          className="h-6 w-6 transition-transform duration-300 group-hover:rotate-12"
-        />
+    {showMobileVariant ? (
+      <div className="flex sm:hidden items-center space-x-1.5 px-2 py-2 rounded-lg transition-all duration-300 group">
+        <span
+          className="font-serif font-bold text-lg text-rose-500 transition-all duration-300"
+          style={{ textShadow: "-1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000" }}
+        >
+          천하
+        </span>
+        <div className="relative">
+          <Image
+            src="/icon.svg"
+            alt="로고"
+            width={24}
+            height={24}
+            className="h-6 w-6 transition-transform duration-300 group-hover:rotate-12"
+          />
+        </div>
+        <span
+          className="font-serif font-bold text-lg text-rose-500 transition-all duration-300"
+          style={{ textShadow: "-1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000" }}
+        >
+          제일
+        </span>
       </div>
-      <span
-        className="font-serif font-bold text-lg text-rose-500 transition-all duration-300"
-        style={{ textShadow: "-1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000" }}
-      >
-        제일
-      </span>
-    </div>
+    ) : null}
   </Link>
 );
 
+function MobileCompanyIdentity({
+  displayName,
+  companyName,
+  logoUrl,
+}: {
+  displayName: string;
+  companyName?: string | null;
+  logoUrl?: string | null;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 sm:hidden">
+      <CompanyLogo
+        companyName={companyName ?? displayName}
+        logoUrl={logoUrl}
+        size={32}
+        className="h-8 w-8"
+      />
+      <div className="min-w-0">
+        <span className="block truncate text-lg font-semibold leading-tight">
+          {displayName}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 export function SiteHeader({ searchData }: SiteHeaderProps) {
+  const { content } = useMobileHeader();
+  const showMobileCompany = content?.type === "company";
+
   return (
     <header
       data-site-header
@@ -78,7 +121,14 @@ export function SiteHeader({ searchData }: SiteHeaderProps) {
     >
       <div className="container mx-auto flex h-16 max-w-screen-xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <div className="flex items-center gap-4">
-          <Logo />
+          <Logo showMobileVariant={!showMobileCompany} />
+          {showMobileCompany && content ? (
+            <MobileCompanyIdentity
+              displayName={content.displayName}
+              companyName={content.companyName}
+              logoUrl={content.logoUrl}
+            />
+          ) : null}
           <div className="hidden md:block">
             <MainNav />
           </div>


### PR DESCRIPTION
## Summary
- add a mobile header context provider so pages can override the global header branding on small screens
- wrap company layouts and update the sticky company header to sync the pinned company identity into the site header on mobile viewports
- adjust the site header to swap the service logo for the company logo/name on mobile while keeping the rest of the navigation responsive

## Testing
- `pnpm lint` *(fails: existing repository lint errors for unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fa77d8c48331a7bf83e2eada0438