### PR TITLE
Reduce mobile spacing on company market cap page

### DIFF
--- a/app/company/[secCode]/marketcap/page.tsx
+++ b/app/company/[secCode]/marketcap/page.tsx
@@ -47,7 +47,7 @@ const SECTION_GRADIENTS: Record<string, CSSProperties> = {
 };
 
 const EDGE_TO_EDGE_SECTION_BASE =
-  "relative -mx-4 space-y-6 border-y px-4 py-6 shadow-sm sm:mx-0 sm:space-y-8 sm:overflow-hidden sm:rounded-3xl sm:border sm:px-6 sm:py-8";
+  "relative -mx-4 space-y-4 border-y px-4 py-4 shadow-sm sm:mx-0 sm:space-y-8 sm:overflow-hidden sm:rounded-3xl sm:border sm:px-6 sm:py-8";
 
 const EDGE_TO_EDGE_CARD_BASE =
   "border border-border/60 bg-background/80 shadow-sm sm:rounded-2xl";
@@ -395,7 +395,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
     const annualDownloadFilename = `${sanitizedSecCode}-annual-marketcap${latestHistoryDate ? `-${latestHistoryDate}` : ""}.csv`;
 
     return (
-      <div className="mt-10 space-y-12 sm:mt-14 sm:space-y-16">
+      <div className="mt-6 space-y-6 sm:mt-14 sm:space-y-16">
         {/* 기업 개요 섹션 */}
         <section
           id="company-overview"
@@ -502,7 +502,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
             </div>
           </header>
 
-          <div className="space-y-6">
+          <div className="space-y-4 sm:space-y-6">
             <InteractiveSecuritiesSection
               companyMarketcapData={companyMarketcapData}
               companySecs={companySecs}
@@ -512,7 +512,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
           </div>
         </section>
 
-        <div className="space-y-6 sm:space-y-8">
+        <div className="space-y-4 sm:space-y-8">
           <CompanyFinancialTabs secCode={secCode} className="-mx-4 sm:mx-0" />
 
           <div
@@ -583,7 +583,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
             )}
           </header>
 
-          <div className="space-y-8">
+          <div className="space-y-5 sm:space-y-8">
             <div>
               <div className={`${EDGE_TO_EDGE_CARD_BASE} p-2 sm:p-4`}>
                 <InteractiveChartSection
@@ -595,7 +595,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
               </div>
             </div>
 
-            <div className="space-y-6">
+            <div className="space-y-4 sm:space-y-6">
               <p className="sr-only">연말 기준 시가총액 추이를 통해 기업의 성장 패턴을 분석합니다</p>
 
               <ListMarketcap
@@ -608,7 +608,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
           </div>
         </section>
 
-        <div className="pt-2">
+        <div className="pt-1 sm:pt-2">
           <CompanyMarketcapPager rank={security.company?.marketcapRank || 1} currentMarket={market} />
         </div>
       </div>
@@ -616,9 +616,9 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
   };
 
   const renderEmptyState = () => (
-    <div className="space-y-12">
+    <div className="space-y-6 sm:space-y-12">
       {/* 🚨 데이터 없음 상태 UI 개선 */}
-        <section className="flex flex-col items-center justify-center gap-6 border border-border/60 bg-muted/40 px-6 py-10 text-center shadow-sm -mx-4 sm:mx-0 sm:rounded-3xl sm:px-8 sm:py-12">
+        <section className="flex flex-col items-center justify-center gap-4 border border-border/60 bg-muted/40 px-4 py-8 text-center shadow-sm -mx-4 sm:mx-0 sm:rounded-3xl sm:px-8 sm:py-12">
           {/* 아이콘 */}
           <div className="flex h-20 w-20 items-center justify-center rounded-full bg-muted/60">
             <svg className="h-10 w-10 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -636,7 +636,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
           </div>
 
           {/* 대안 액션 */}
-          <div className="flex flex-col gap-3 pt-2 sm:flex-row">
+          <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:gap-3">
             <Link
               href={`/company/${secCode}`}
               className="inline-flex items-center justify-center rounded-lg bg-muted px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/80"
@@ -653,7 +653,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
         </section>
 
         {companySecs.length > 0 ? (
-          <section className="space-y-6">
+          <section className="space-y-4 sm:space-y-6">
             <h2 className="text-2xl font-bold tracking-tight text-foreground">
               관련 종목 ({companySecs.length}개)
             </h2>
@@ -669,7 +669,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
               ))}
             </div>
 
-            <div className="pt-6 text-center">
+            <div className="pt-4 text-center sm:pt-6">
               <Link
                 href={`/security/${secCode}/marketcap`}
                 className="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 sm:px-6 sm:py-3"
@@ -702,7 +702,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
       );
 
   return (
-    <main className="relative py-6 lg:gap-10 lg:py-8 xl:grid xl:grid-cols-[1fr_300px]">
+    <main className="relative py-4 sm:py-6 lg:gap-10 lg:py-8 xl:grid xl:grid-cols-[1fr_300px]">
       <div className="mx-auto w-full min-w-0">
         {/* 브레드크럼 네비게이션 */}
         <nav
@@ -730,7 +730,7 @@ export default async function CompanyMarketcapPage({ params }: CompanyMarketcapP
           logoUrl={security.company?.logo}
         />
 
-        <div className="mt-6 space-y-5 sm:mt-8 sm:space-y-6">
+        <div className="mt-5 space-y-4 sm:mt-8 sm:space-y-6">
           <p className="text-base text-muted-foreground md:text-lg">
             기업 전체 가치와 종목별 시가총액 구성을 분석합니다
           </p>

--- a/app/company/layout.tsx
+++ b/app/company/layout.tsx
@@ -2,6 +2,7 @@ import { getSecuritySearchNames } from "@/lib/getSearch";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 import { BottomNavigation } from "@/components/bottom-navigation";
+import { MobileHeaderProvider } from "@/components/mobile-header-context";
 
 interface CompanyLayoutProps {
   children: React.ReactNode;
@@ -11,7 +12,7 @@ export default async function CompanyLayout({ children }: CompanyLayoutProps) {
   const searchData = await getSecuritySearchNames();
 
   return (
-    <>
+    <MobileHeaderProvider>
       <SiteHeader searchData={searchData} />
       <main className="flex-1 pb-20 md:pb-0">
         <div className="container mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
@@ -20,6 +21,6 @@ export default async function CompanyLayout({ children }: CompanyLayoutProps) {
       </main>
       <SiteFooter />
       <BottomNavigation />
-    </>
+    </MobileHeaderProvider>
   );
 }

--- a/components/key-metrics-section.tsx
+++ b/components/key-metrics-section.tsx
@@ -33,7 +33,7 @@ const DEFAULT_BACKGROUND: CSSProperties = {
 };
 
 const EDGE_TO_EDGE_SECTION_CLASS =
-    "relative -mx-4 space-y-6 border-y px-4 py-6 shadow-sm sm:mx-0 sm:space-y-8 sm:overflow-hidden sm:rounded-3xl sm:border sm:px-6 sm:py-8";
+    "relative -mx-4 space-y-4 border-y px-4 py-4 shadow-sm sm:mx-0 sm:space-y-8 sm:overflow-hidden sm:rounded-3xl sm:border sm:px-6 sm:py-8";
 
 const MARQUEE_CARD_STYLE: CSSProperties = {
     width: "min(calc((100vw - 16px) / 5.5), 140px)",

--- a/components/mobile-header-context.tsx
+++ b/components/mobile-header-context.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type MobileHeaderContent = {
+  type: "company";
+  displayName: string;
+  companyName?: string | null;
+  logoUrl?: string | null;
+};
+
+type MobileHeaderContextValue = {
+  content: MobileHeaderContent | null;
+  setContent: (content: MobileHeaderContent | null) => void;
+};
+
+const noop = () => {};
+
+const defaultValue: MobileHeaderContextValue = {
+  content: null,
+  setContent: noop,
+};
+
+const MobileHeaderContext = createContext<MobileHeaderContextValue | undefined>(
+  undefined
+);
+
+export function MobileHeaderProvider({ children }: { children: ReactNode }) {
+  const [content, setContentState] = useState<MobileHeaderContent | null>(null);
+
+  const setContent = useCallback((next: MobileHeaderContent | null) => {
+    setContentState(prev => {
+      if (prev === next) {
+        return prev;
+      }
+
+      if (!prev && !next) {
+        return prev;
+      }
+
+      if (!prev || !next) {
+        return next ?? null;
+      }
+
+      const isSame =
+        prev.type === next.type &&
+        prev.displayName === next.displayName &&
+        prev.companyName === next.companyName &&
+        prev.logoUrl === next.logoUrl;
+
+      return isSame ? prev : next;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      content,
+      setContent,
+    }),
+    [content, setContent]
+  );
+
+  return (
+    <MobileHeaderContext.Provider value={value}>
+      {children}
+    </MobileHeaderContext.Provider>
+  );
+}
+
+export function useMobileHeader() {
+  return useContext(MobileHeaderContext) ?? defaultValue;
+}
+

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,9 +1,16 @@
+"use client";
+
 import Link from "next/link";
 import Image from "next/image";
+import { Balancer } from "react-wrap-balancer";
+
+import CompanyLogo from "@/components/CompanyLogo";
+import { CommandMenu } from "@/components/command-menu";
 import { MainNav } from "@/components/main-nav";
 import { MobileNav } from "@/components/mobile-nav";
 import { ModeToggle } from "@/components/mode-toggle";
-import { CommandMenu } from "@/components/command-menu";
+import { useMobileHeader } from "@/components/mobile-header-context";
+import { cn } from "@/lib/utils";
 
 // Define props for SiteHeader to accept searchData
 interface SiteHeaderProps {
@@ -16,8 +23,14 @@ interface SiteHeaderProps {
   }[];
 }
 
-const Logo = () => (
-  <Link href="/" className="flex items-center space-x-2">
+const Logo = ({ showMobileVariant = true }: { showMobileVariant?: boolean }) => (
+  <Link
+    href="/"
+    className={cn(
+      "items-center space-x-2",
+      showMobileVariant ? "flex" : "hidden sm:flex"
+    )}
+  >
     {/* Default (sm and up) */}
     <div className="hidden sm:flex items-center space-x-1.5 px-3 py-2 rounded-lg transition-all duration-300 group">
       <span
@@ -44,33 +57,64 @@ const Logo = () => (
     </div>
 
     {/* XS layout */}
-    <div className="flex sm:hidden items-center space-x-1.5 px-2 py-2 rounded-lg transition-all duration-300 group">
-      <span
-        className="font-serif font-bold text-lg text-rose-500 transition-all duration-300"
-        style={{ textShadow: "-1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000" }}
-      >
-        천하
-      </span>
-      <div className="relative">
-        <Image
-          src="/icon.svg"
-          alt="로고"
-          width={24}
-          height={24}
-          className="h-6 w-6 transition-transform duration-300 group-hover:rotate-12"
-        />
+    {showMobileVariant ? (
+      <div className="flex sm:hidden items-center space-x-1.5 px-2 py-2 rounded-lg transition-all duration-300 group">
+        <span
+          className="font-serif font-bold text-lg text-rose-500 transition-all duration-300"
+          style={{ textShadow: "-1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000" }}
+        >
+          천하
+        </span>
+        <div className="relative">
+          <Image
+            src="/icon.svg"
+            alt="로고"
+            width={24}
+            height={24}
+            className="h-6 w-6 transition-transform duration-300 group-hover:rotate-12"
+          />
+        </div>
+        <span
+          className="font-serif font-bold text-lg text-rose-500 transition-all duration-300"
+          style={{ textShadow: "-1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000" }}
+        >
+          제일
+        </span>
       </div>
-      <span
-        className="font-serif font-bold text-lg text-rose-500 transition-all duration-300"
-        style={{ textShadow: "-1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000" }}
-      >
-        제일
-      </span>
-    </div>
+    ) : null}
   </Link>
 );
 
+function MobileCompanyIdentity({
+  displayName,
+  companyName,
+  logoUrl,
+}: {
+  displayName: string;
+  companyName?: string | null;
+  logoUrl?: string | null;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-3 rounded-lg px-2 py-1.5 sm:hidden">
+      <CompanyLogo
+        companyName={companyName ?? displayName}
+        logoUrl={logoUrl}
+        size={40}
+        className="h-10 w-10 flex-shrink-0 shadow-sm"
+      />
+      <div className="min-w-0">
+        <h1 className="font-heading text-lg font-bold leading-tight tracking-tight">
+          <Balancer>{displayName} 시가총액</Balancer>
+        </h1>
+      </div>
+    </div>
+  );
+}
+
 export function SiteHeader({ searchData }: SiteHeaderProps) {
+  const { content } = useMobileHeader();
+  const showMobileCompany = content?.type === "company";
+
   return (
     <header
       data-site-header
@@ -78,7 +122,14 @@ export function SiteHeader({ searchData }: SiteHeaderProps) {
     >
       <div className="container mx-auto flex h-16 max-w-screen-xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <div className="flex items-center gap-4">
-          <Logo />
+          <Logo showMobileVariant={!showMobileCompany} />
+          {showMobileCompany && content ? (
+            <MobileCompanyIdentity
+              displayName={content.displayName}
+              companyName={content.companyName}
+              logoUrl={content.logoUrl}
+            />
+          ) : null}
           <div className="hidden md:block">
             <MainNav />
           </div>


### PR DESCRIPTION
## Summary
- decrease default spacing and padding for company market cap sections on small screens while preserving desktop layout
- tighten empty state and pager spacing so more content is visible when the mobile header shows company info
- align key metrics section container spacing with the new mobile scale

## Testing
- `pnpm lint` *(fails: numerous pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fa77d8c48331a7bf83e2eada0438