### PR TITLE
Align security marketcap charts with company visuals

### DIFF
--- a/app/security/[secCode]/marketcap/page.tsx
+++ b/app/security/[secCode]/marketcap/page.tsx
@@ -38,7 +38,7 @@ import { PageNavigation } from "@/components/page-navigation";
 import { StickyCompanyHeader } from "@/components/sticky-company-header";
 import { CsvDownloadButton } from "@/components/CsvDownloadButton";
 import { SecMarketcapPager } from "@/components/pager-marketcap-security";
-import ChartMarketcap from "@/components/chart-marketcap";
+import SecurityMarketcapChart from "@/components/security-marketcap-chart";
 import { Card, CardContent } from "@/components/ui/card";
 import type { Price } from "@/typings";
 
@@ -191,6 +191,11 @@ export default async function SecurityMarketcapPage({
       ? security.name
       : null;
   const securityType = security.type || "종목";
+  const selectedType = resolveSelectedType(security.type);
+  const chartSeriesKey =
+    selectedType === "시가총액 구성"
+      ? "총합계"
+      : [displayName, securityType].filter(Boolean).join(" ").trim();
 
   const market = secCode.includes(".")
     ? secCode.split(".")[0]
@@ -263,12 +268,12 @@ export default async function SecurityMarketcapPage({
     : marketcapHistory.slice(-90)
   ).map((item) => ({
     date: item.date.toISOString().split("T")[0],
-    totalValue: item.value,
+    [chartSeriesKey]: item.value,
   }));
 
   const fullChartData = marketcapHistory.map((item) => ({
     date: item.date.toISOString().split("T")[0],
-    totalValue: item.value,
+    [chartSeriesKey]: item.value,
   }));
 
   const listData = marketcapHistory.map((item) => ({
@@ -425,11 +430,9 @@ export default async function SecurityMarketcapPage({
       companyMarketcapData?.securities?.length,
   );
 
-  const selectedType = resolveSelectedType(security.type);
-
-  const annualCsvData = fullChartData.map((item) => ({
-    date: item.date,
-    marketcap: item.totalValue,
+  const annualCsvData = marketcapHistory.map((item) => ({
+    date: item.date.toISOString().split("T")[0],
+    marketcap: item.value,
   }));
 
   const latestHistoryDate = annualCsvData.at(-1)?.date;
@@ -624,11 +627,10 @@ export default async function SecurityMarketcapPage({
               </div>
               <div className="flex flex-1 flex-col px-3 pb-4 pt-3 sm:px-5 sm:pb-5">
                 <div className="min-h-[260px] flex-1">
-                  <ChartMarketcap
+                  <SecurityMarketcapChart
                     data={marketcapChartData}
-                    format="formatNumber"
-                    formatTooltip="formatNumberTooltip"
-                    selectedType="시가총액 구성"
+                    type="summary"
+                    selectedType={selectedType}
                   />
                 </div>
               </div>
@@ -769,11 +771,10 @@ export default async function SecurityMarketcapPage({
 
           <div className="space-y-5 sm:space-y-8">
             <div className={`${EDGE_TO_EDGE_CARD_BASE} p-2 sm:p-4`}>
-              <ChartMarketcap
+              <SecurityMarketcapChart
                 data={fullChartData}
-                format="formatNumber"
-                formatTooltip="formatNumberTooltip"
-                selectedType="시가총액 구성"
+                type="detailed"
+                selectedType={selectedType}
               />
             </div>
 

--- a/components/security-marketcap-chart.tsx
+++ b/components/security-marketcap-chart.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import ChartA11yDescription from "./chart-a11y-description";
+import ChartCompanyMarketcap from "./chart-company-marketcap";
+import ChartMarketcap from "./chart-marketcap";
+
+type DataPoint = {
+  date: string;
+  [key: string]: string | number | null | undefined;
+};
+
+interface SecurityMarketcapChartProps {
+  data: DataPoint[];
+  type: "summary" | "detailed";
+  selectedType?: string;
+}
+
+export default function SecurityMarketcapChart({
+  data,
+  type,
+  selectedType = "시가총액 구성",
+}: SecurityMarketcapChartProps) {
+  const safeData = Array.isArray(data) ? data : [];
+
+  return (
+    <div className="transition-all duration-300 ease-in-out w-full flex-1">
+      <ChartA11yDescription
+        data={safeData}
+        selectedType={selectedType}
+        type={type}
+      />
+      {type === "summary" ? (
+        <ChartCompanyMarketcap
+          data={safeData}
+          format="formatNumber"
+          formatTooltip="formatNumberTooltip"
+          selectedType={selectedType}
+        />
+      ) : (
+        <ChartMarketcap
+          data={safeData}
+          format="formatNumber"
+          formatTooltip="formatNumberTooltip"
+          selectedType={selectedType}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- reuse the company marketcap chart components on the security detail page so the daily and annual trend visuals match
- introduce a small client wrapper component to render the company-style chart with security-specific data and annotations
- normalize the security marketcap history data shape and CSV generation to suit the new chart component

## Testing
- pnpm lint *(fails: repository already has unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d3188f37d88331add65a153b12039f